### PR TITLE
feat: Allow setting of EncMode and ECLevel via ImageOption

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -15,14 +15,14 @@ type encMode uint
 const (
 	// encModeNone mode ...
 	encModeNone encMode = 1 << iota
-	// encModeNumeric mode ...
-	encModeNumeric
-	// encModeAlphanumeric mode ...
-	encModeAlphanumeric
-	// encModeByte mode ...
-	encModeByte
-	// encModeJP mode ...
-	encModeJP
+	// EncModeNumeric mode ...
+	EncModeNumeric
+	// EncModeAlphanumeric mode ...
+	EncModeAlphanumeric
+	// EncModeByte mode ...
+	EncModeByte
+	// EncModeJP mode ...
+	EncModeJP
 )
 
 var (
@@ -35,13 +35,13 @@ func getEncModeName(mode encMode) string {
 	switch mode {
 	case encModeNone:
 		return "none"
-	case encModeNumeric:
+	case EncModeNumeric:
 		return "numeric"
-	case encModeAlphanumeric:
+	case EncModeAlphanumeric:
 		return "alphanumeric"
-	case encModeByte:
+	case EncModeByte:
 		return "byte"
-	case encModeJP:
+	case EncModeJP:
 		return "japan"
 	default:
 		return "unknown"
@@ -51,13 +51,13 @@ func getEncModeName(mode encMode) string {
 // getEncodeModeIndicator ...
 func getEncodeModeIndicator(mode encMode) *binary.Binary {
 	switch mode {
-	case encModeNumeric:
+	case EncModeNumeric:
 		return binary.New(false, false, false, true)
-	case encModeAlphanumeric:
+	case EncModeAlphanumeric:
 		return binary.New(false, false, true, false)
-	case encModeByte:
+	case EncModeByte:
 		return binary.New(false, true, false, false)
-	case encModeJP:
+	case EncModeJP:
 		return binary.New(true, false, false, false)
 	default:
 		panic("no indicator")
@@ -94,13 +94,13 @@ func (e *encoder) Encode(byts []byte) (*binary.Binary, error) {
 
 	// encode data with specified mode
 	switch e.mode {
-	case encModeNumeric:
+	case EncModeNumeric:
 		e.encodeNumeric()
-	case encModeAlphanumeric:
+	case EncModeAlphanumeric:
 		e.encodeAlphanumeric()
-	case encModeByte:
+	case EncModeByte:
 		e.encodeByte()
-	case encModeJP:
+	case EncModeJP:
 		panic("this has not been finished")
 	}
 
@@ -274,38 +274,38 @@ func encodeAlphanumericCharacter(v byte) uint32 {
 type analyzeEncFunc func(byte) bool
 
 // analyzeMode try to detect letter set of input data, so that encoder can determine which mode should be use.
-// case1: only numbers, use encModeNumeric.
-// case2: could not use encModeNumeric, but you can find all of them in character mapping, use encModeAlphanumeric.
-// case3: could not use encModeAlphanumeric, but you can find all of them in ISO-8859-1 character set, use encModeByte.
-// case4: could not use encModeByte, use encModeJP, no more choice.
+// case1: only numbers, use EncModeNumeric.
+// case2: could not use EncModeNumeric, but you can find all of them in character mapping, use EncModeAlphanumeric.
+// case3: could not use EncModeAlphanumeric, but you can find all of them in ISO-8859-1 character set, use EncModeByte.
+// case4: could not use EncModeByte, use EncModeJP, no more choice.
 //
 // Links: https://en.wikipedia.org/wiki/QR_code Storage section.
 func analyzeMode(raw []byte) encMode {
 	var (
 		analyzeFn analyzeEncFunc = analyzeNum
-		mode                     = encModeNumeric
+		mode                     = EncModeNumeric
 	)
 
 	// loop to check each character in raw data,
 	// from low mode to higher while current mode could bearing the input data.
 	for _, byt := range raw {
 		switch mode {
-		case encModeNumeric:
+		case EncModeNumeric:
 			if !analyzeFn(byt) {
-				mode = encModeAlphanumeric
+				mode = EncModeAlphanumeric
 				analyzeFn = analyzeAlphaNum
 			}
-		case encModeAlphanumeric:
+		case EncModeAlphanumeric:
 			if !analyzeFn(byt) {
-				mode = encModeByte
+				mode = EncModeByte
 				//analyzeFn = analyzeByte
 			}
-		case encModeByte:
+		case EncModeByte:
 			return mode
 			//if !analyzeFn(byt) {
-			//	mode = encModeJP
+			//	mode = EncModeJP
 			//}
-			//case encModeJP:
+			//case EncModeJP:
 			//	return mode
 		}
 	}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -11,7 +11,7 @@ import (
 func TestEncodeNum(t *testing.T) {
 	enc := encoder{
 		ecLv:    Low,
-		mode:    encModeNumeric,
+		mode:    EncModeNumeric,
 		version: loadVersion(1, Low),
 	}
 
@@ -26,7 +26,7 @@ func TestEncodeNum(t *testing.T) {
 func TestEncodeAlphanum(t *testing.T) {
 	enc := encoder{
 		ecLv:    Low,
-		mode:    encModeAlphanumeric,
+		mode:    EncModeAlphanumeric,
 		version: loadVersion(1, Low),
 	}
 
@@ -41,7 +41,7 @@ func TestEncodeAlphanum(t *testing.T) {
 func TestEncodeByte(t *testing.T) {
 	enc := encoder{
 		ecLv:    Quart,
-		mode:    encModeByte,
+		mode:    EncModeByte,
 		version: loadVersion(5, Quart),
 	}
 
@@ -163,37 +163,37 @@ func Test_anlayzeMode(t *testing.T) {
 		{
 			name: "case 0",
 			args: args{raw: []byte("123120899231")},
-			want: encModeNumeric,
+			want: EncModeNumeric,
 		},
 		{
 			name: "case 1",
 			args: args{raw: []byte(":/1231H208*99231FBJO")},
-			want: encModeAlphanumeric,
+			want: EncModeAlphanumeric,
 		},
 		{
 			name: "case 2",
 			args: args{raw: []byte("hahah1298312hG&^FBJO@jhgG*")},
-			want: encModeByte,
+			want: EncModeByte,
 		},
 		{
 			name: "case 3",
 			args: args{raw: []byte("JKAHDOIANKQOIHCMJKASJ")},
-			want: encModeAlphanumeric,
+			want: EncModeAlphanumeric,
 		},
 		{
 			name: "case 4",
 			args: args{raw: []byte("https://baidu.com?keyword=_JSO==GA")},
-			want: encModeByte,
+			want: EncModeByte,
 		},
 		{
 			name: "case 5",
 			args: args{raw: []byte("这是汉字也应该是EncModeByte")},
-			want: encModeByte,
+			want: EncModeByte,
 		},
 		{
 			name: "case 6 (swedish letter)",
 			args: args{raw: []byte("Övrigt aksldjlk Övrigt should JP encMode?")},
-			want: encModeByte,
+			want: EncModeByte,
 		},
 	}
 	for _, tt := range tests {

--- a/image_option.go
+++ b/image_option.go
@@ -17,6 +17,8 @@ func defaultOutputOption() *outputImageOptions {
 		qrWidth:      20,              //
 		shape:        _shapeRectangle, //
 		imageEncoder: jpegEncoder{},
+		encMode:      EncModeByte,
+		ecLevel:      Quart,
 	}
 }
 
@@ -40,6 +42,12 @@ type outputImageOptions struct {
 
 	// imageEncoder specify which file format would be encoded the QR image.
 	imageEncoder ImageEncoder
+
+	// encMode specifies which encMode to use
+	encMode encMode
+
+	// ecLevel specifies which ecLevel to use
+	ecLevel ecLevel
 }
 
 func (oo *outputImageOptions) backgroundColor() color.Color {

--- a/image_option_api.go
+++ b/image_option_api.go
@@ -163,3 +163,18 @@ func WithCustomImageEncoder(encoder ImageEncoder) ImageOption {
 		oo.imageEncoder = encoder
 	})
 }
+
+// WithEncodingMode to specify which encMode to use
+func WithEncodingMode(mode encMode) ImageOption {
+	return newFuncDialOption(func(oo *outputImageOptions) {
+		oo.encMode = mode
+	})
+}
+
+// WithBuiltinImageEncoder to use custom image encoder to encode image.Image into
+// io.Writer
+func WithErrorCorrectionLevel(level ecLevel) ImageOption {
+	return newFuncDialOption(func(oo *outputImageOptions) {
+		oo.ecLevel = level
+	})
+}

--- a/qrcode.go
+++ b/qrcode.go
@@ -31,7 +31,8 @@ func New(text string, opts ...ImageOption) (*QRCode, error) {
 
 	qrc := &QRCode{
 		content:      text,
-		mode:         encModeByte,
+		mode:         dst.encMode,
+		ecLv:         dst.ecLevel,
 		needAnalyze:  true,
 		outputOption: dst,
 	}
@@ -55,8 +56,8 @@ func NewWithSpecV(text string, ver int, ecLv ecLevel, opts ...ImageOption) (*QRC
 	qrc := &QRCode{
 		content:      text,
 		ver:          ver,
-		mode:         encModeByte,
-		ecLv:         ecLv,
+		mode:         dst.encMode,
+		ecLv:         dst.ecLevel,
 		needAnalyze:  false,
 		outputOption: dst,
 	}
@@ -148,11 +149,10 @@ func (q *QRCode) init() error {
 
 // analyze choose version and encoder
 func (q *QRCode) analyze() error {
-	// choose error correction level
-	q.ecLv = Quart
-
-	// choose encode mode (num, alpha num, byte, Japanese)
-	q.mode = analyzeMode(q.rawData)
+	if q.mode == 0 {
+		// choose encode mode (num, alpha num, byte, Japanese)
+		q.mode = analyzeMode(q.rawData)
+	}
 
 	// analyze content to decide version etc.
 	analyzedV, err := analyzeVersion(q.rawData, q.ecLv, q.mode)

--- a/qrcode_test.go
+++ b/qrcode_test.go
@@ -15,7 +15,7 @@ func TestNew(t *testing.T) {
 	t.Logf("analyzed version is: %d, len of data: %d, encMode: %v",
 		qrc.v, len(qrc.rawData), qrc.mode)
 
-	if qrc.mode != encModeByte {
+	if qrc.mode != EncModeByte {
 		t.Error("could analyze error with encode type")
 		t.Fail()
 	}

--- a/version.go
+++ b/version.go
@@ -246,13 +246,13 @@ func analyzeVersion(raw []byte, ecLv ecLevel, eMode encMode) (*version, error) {
 	for _, v := range versions {
 		if v.ECLevel == ecLv {
 			switch eMode {
-			case encModeNumeric:
+			case EncModeNumeric:
 				c = v.Cap.Numeric
-			case encModeAlphanumeric:
+			case EncModeAlphanumeric:
 				c = v.Cap.AlphaNumeric
-			case encModeByte:
+			case EncModeByte:
 				c = v.Cap.Byte
-			case encModeJP:
+			case EncModeJP:
 				c = v.Cap.JP
 			default:
 				return nil, errMissMatchedEncodeType

--- a/version_test.go
+++ b/version_test.go
@@ -255,7 +255,7 @@ func Test_analyzeVersion(t *testing.T) {
 			args: args{
 				raw:   []byte("TEXT"),
 				ecLv:  Medium,
-				eMode: encModeAlphanumeric,
+				eMode: EncModeAlphanumeric,
 			},
 			want:    &v,
 			wantErr: false,


### PR DESCRIPTION
Currently its not possible to specify the encoding mode. This change adds the option for this and also allows setting the error correction level without specifying the version