### PR TITLE
bug(writer): pre-multiply RGB by A

### DIFF
--- a/writer/standard/image_option.go
+++ b/writer/standard/image_option.go
@@ -142,6 +142,10 @@ func (oo *outputImageOptions) translateToRGBA(v qrcode.QRValue) (rgba color.RGBA
 
 	if oo.bgTransparent {
 		(&oo.bgColor).A = 0x00
+		// color.RGBA is pre-multiplied by alpha, so set RGB to 0 when fully transparent.
+		(&oo.bgColor).R = 0x00
+		(&oo.bgColor).G = 0x00
+		(&oo.bgColor).B = 0x00
 	}
 	rgba = oo.bgColor
 


### PR DESCRIPTION
color.RGBA is pre-multiplied by alpha. When A is 0 the only valid value for R, G and B is 0.

When drawing a logo with an alpha channel the blending operation may overflow when R, G, B have invalid values (i.e larger than A).