### PR TITLE
Cleanup/improve safety: remove goto and potentially unbounded for loop

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -55,7 +55,7 @@ func TestEncodeByte(t *testing.T) {
 
 func Test_analyzeNum(t *testing.T) {
 	type args struct {
-		byt byte
+		input rune
 	}
 	tests := []struct {
 		name string
@@ -64,33 +64,33 @@ func Test_analyzeNum(t *testing.T) {
 	}{
 		{
 			name: "case 0",
-			args: args{byt: '0'},
+			args: args{input: '0'},
 			want: true,
 		},
 		{
 			name: "case 1",
-			args: args{byt: 'a'},
+			args: args{input: 'a'},
 			want: false,
 		},
 		{
 			name: "case 2",
-			args: args{byt: 'A'},
+			args: args{input: 'A'},
 			want: false,
 		},
 		{
 			name: "case 3",
-			args: args{byt: '9'},
+			args: args{input: '9'},
 			want: true,
 		},
 		{
 			name: "case 4",
-			args: args{byt: '*'},
+			args: args{input: '*'},
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := analyzeNum(tt.args.byt); got != tt.want {
+			if got := analyzeNum(tt.args.input); got != tt.want {
 				t.Errorf("analyzeNum() = %v, want %v", got, tt.want)
 			}
 		})
@@ -99,7 +99,7 @@ func Test_analyzeNum(t *testing.T) {
 
 func Test_analyzeAlphanum(t *testing.T) {
 	type args struct {
-		byt byte
+		input rune
 	}
 	tests := []struct {
 		name string
@@ -108,43 +108,43 @@ func Test_analyzeAlphanum(t *testing.T) {
 	}{
 		{
 			name: "case 0",
-			args: args{byt: '0'},
+			args: args{input: '0'},
 			want: true,
 		},
 		{
 			name: "case 1",
-			args: args{byt: 'a'},
+			args: args{input: 'a'},
 			want: false,
 		},
 		{
 			name: "case 2",
-			args: args{byt: 'A'},
+			args: args{input: 'A'},
 			want: true,
 		},
 		{
 			name: "case 3",
-			args: args{byt: '9'},
+			args: args{input: '9'},
 			want: true,
 		},
 		{
 			name: "case 4",
-			args: args{byt: '*'},
+			args: args{input: '*'},
 			want: true,
 		},
 		{
 			name: "case 5",
-			args: args{byt: '?'},
+			args: args{input: '?'},
 			want: false,
 		},
 		{
 			name: "case 6",
-			args: args{byt: '&'},
+			args: args{input: '&'},
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := analyzeAlphaNum(tt.args.byt); got != tt.want {
+			if got := analyzeAlphaNum(tt.args.input); got != tt.want {
 				t.Errorf("analyzeAlphaNum() = %v, want %v", got, tt.want)
 			}
 		})

--- a/qrcode.go
+++ b/qrcode.go
@@ -97,7 +97,7 @@ func (q *QRCode) init() (err error) {
 		return fmt.Errorf("init: calc version failed: %v", err)
 	}
 	q.mat = newMatrix(q.v.Dimension(), q.v.Dimension())
-	_ = q.applyEncoder()
+	q.applyEncoder()
 
 	var (
 		dataBlocks []dataBlock // data encoding blocks
@@ -153,11 +153,9 @@ func (q *QRCode) calcVersion() (ver *version, err error) {
 	return
 }
 
-// applyEncoder
-func (q *QRCode) applyEncoder() error {
+// applyEncoder sets the encoder based on encoding mode, error correction level, and version.
+func (q *QRCode) applyEncoder()  {
 	q.encoder = newEncoder(q.encodingOption.EncMode, q.encodingOption.EcLevel, q.v)
-
-	return nil
 }
 
 // dataEncoding ref to:

--- a/writer/standard/writer.go
+++ b/writer/standard/writer.go
@@ -193,14 +193,15 @@ func draw(mat qrcode.Matrix, opt *outputImageOptions) image.Image {
 		if !validLogoImage(w, h, logoWidth, logoHeight, opt.logoSizeMultiplier) {
 			log.Printf("w=%d, h=%d, logoW=%d, logoH=%d, logo is over than 1/%d of QRCode \n",
 				w, h, logoWidth, logoHeight, opt.logoSizeMultiplier)
-			goto done
+
+			return dc.Image()
 		}
 
 		// DONE(@yeqown): calculate the xOffset and yOffset which point(xOffset, yOffset)
 		// should icon upper-left to start
 		dc.DrawImage(opt.logoImage(), (w-logoWidth)/2, (h-logoHeight)/2)
 	}
-done:
+
 	return dc.Image()
 }
 


### PR DESCRIPTION
This pr contains several fixes but primarily aims to make `analyzeEncodeModeFromRaw` safer by removing the use of a goto statement along with complex boolean checking. Aim is to make this library safer to use in production with web services.

- reduces the need for fuzing by using simpler logic
- passes existing tests
- loop cannot explode and run unbounded on bad input(ie if boolean logic was subtly incorrect it only looks at each byte once instead of multiple times)

Also includes cleanups to further document some methods/variables and remove unused error return value.