### PR TITLE
feat(writer/standard): add gradient painting

### DIFF
--- a/example/with-gradient-color/main.go
+++ b/example/with-gradient-color/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"image/color"
+
+	"github.com/yeqown/go-qrcode/v2"
+	"github.com/yeqown/go-qrcode/writer/standard"
+)
+
+func main() {
+	qrc, err := qrcode.NewWith("https://github.com/yeqown/go-qrcode", qrcode.WithErrorCorrectionLevel(qrcode.ErrorCorrectionLow))
+	if err != nil {
+		panic(err)
+	}
+	g := standard.NewGradient(45, []standard.ColorStop{
+		{
+			T:     0,
+			Color: color.RGBA{R: 255, G: 0, B: 0, A: 255},
+		},
+		{
+			T:     0.5,
+			Color: color.RGBA{R: 0, G: 255, B: 0, A: 255},
+		},
+		{
+			T:     1,
+			Color: color.RGBA{R: 0, G: 0, B: 255, A: 255},
+		},
+	}...)
+	w, err := standard.New("./with-gradient-color/smaller.png",
+		standard.WithFgGradient(g),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = qrc.Save(w)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/writer/standard/gradient.go
+++ b/writer/standard/gradient.go
@@ -1,0 +1,117 @@
+package standard
+
+import (
+	"image"
+	"image/color"
+	draw2 "image/draw"
+	"math"
+	"sort"
+)
+
+// ColorStop represents a single color stop in a gradient.
+// T defines the position along the gradient line, ranging from 0.0 to 1.0.
+// Color defines the color at this stop.
+type ColorStop struct {
+	T     float64 // from 0.0 to 1.0.
+	Color color.RGBA
+}
+
+// LinearGradient defines a linear gradient with angle and color stops.
+// The gradient progresses in the direction of the given angle (in degrees).
+// Angle is interpreted as: 0 - right, 90 - up, 180 - left, 270 - down.
+type LinearGradient struct {
+	Stops []ColorStop // Ordered list of color stops along the gradient
+	Angle float64     // Gradient angle in degrees
+}
+
+// NewGradient creates a new LinearGradient with the specified angle (in degrees) and color stops.
+// The stops are sorted in ascending order of T.
+func NewGradient(angle float64, stops ...ColorStop) *LinearGradient {
+	sort.Slice(stops, func(i, j int) bool {
+		return stops[i].T < stops[j].T
+	})
+	return &LinearGradient{Stops: stops, Angle: angle}
+
+}
+
+// applyGradient applies the linear gradient to all pixels in the image that match the given foreground color.
+func (g *LinearGradient) applyGradient(img image.Image, fgColor color.RGBA) *image.RGBA {
+	// Convert angle to radians and compute gradient direction vector
+	angleRad := g.Angle * math.Pi / 180.0
+	dx := math.Cos(angleRad)
+	dy := -math.Sin(angleRad)
+
+	bounds := img.Bounds()
+	xmin, xmax := float64(bounds.Min.X), float64(bounds.Max.X)
+	ymin, ymax := float64(bounds.Min.Y), float64(bounds.Max.Y)
+
+	// Get all 4 corners of the image
+	corners := [4][2]float64{
+		{xmin, ymin},
+		{xmin, ymax},
+		{xmax, ymin},
+		{xmax, ymax},
+	}
+
+	// Compute min and max projection of corners on the gradient axis
+	minProj, maxProj := math.Inf(1), math.Inf(-1)
+	for _, p := range corners {
+		proj := p[0]*dx + p[1]*dy
+		if proj < minProj {
+			minProj = proj
+		}
+		if proj > maxProj {
+			maxProj = proj
+		}
+	}
+
+	// Prepare output image
+	out := image.NewRGBA(bounds)
+	draw2.Draw(out, bounds, img, bounds.Min, draw2.Src)
+
+	// Replace foreGround pixels with interpolated gradient colors
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			c := img.At(x, y)
+			if c == fgColor {
+				// Project pixel onto gradient axis
+				proj := float64(x)*dx + float64(y)*dy
+				// Normalize to [0, 1]
+				t := (proj - minProj) / (maxProj - minProj)
+				// Set pixel color from gradient
+				out.Set(x, y, interpolateColor(g.Stops, t))
+			}
+		}
+	}
+	return out
+}
+
+// interpolateColor returns a color interpolated from the gradient stops based on position t.
+func interpolateColor(stops []ColorStop, t float64) color.RGBA {
+	if t <= stops[0].T {
+		return stops[0].Color
+	}
+	if t >= stops[len(stops)-1].T {
+		return stops[len(stops)-1].Color
+	}
+	for i := 0; i < len(stops)-1; i++ {
+		start := stops[i]
+		end := stops[i+1]
+		if t >= start.T && t <= end.T {
+			// Linear interpolation between two stops
+			factor := (t - start.T) / (end.T - start.T)
+			return blendColors(start.Color, end.Color, factor)
+		}
+	}
+	return color.RGBA{A: 255} // fallback (should not happen)
+}
+
+// blendColors returns the color interpolated between c1 and c2 using t in [0.0 - 1.0].
+func blendColors(c1, c2 color.RGBA, t float64) color.RGBA {
+	return color.RGBA{
+		R: uint8(float64(c1.R)*(1-t) + float64(c2.R)*t),
+		G: uint8(float64(c1.G)*(1-t) + float64(c2.G)*t),
+		B: uint8(float64(c1.B)*(1-t) + float64(c2.B)*t),
+		A: 255,
+	}
+}

--- a/writer/standard/image_option.go
+++ b/writer/standard/image_option.go
@@ -37,6 +37,9 @@ type outputImageOptions struct {
 	// qrColor is the foreground color of the QR code.
 	qrColor color.RGBA
 
+	// qrGradient is an optional linear gradient to apply to QR modules instead of a solid color.
+	qrGradient *LinearGradient
+
 	// logo this icon image would be put the center of QR Code image
 	// NOTE: logo only should have 1 / logoSizeMultiplier size of QRCode image
 	logo image.Image

--- a/writer/standard/image_option_api.go
+++ b/writer/standard/image_option_api.go
@@ -74,6 +74,17 @@ func WithFgColorRGBHex(hex string) ImageOption {
 	})
 }
 
+// WithFgGradient QR gradient
+func WithFgGradient(g *LinearGradient) ImageOption {
+	return newFuncOption(func(oo *outputImageOptions) {
+		if g == nil || len(g.Stops) == 0 {
+			return
+		}
+
+		oo.qrGradient = g
+	})
+}
+
 // WithLogoImage image should only has 1/5 width of QRCode at most
 func WithLogoImage(img image.Image) ImageOption {
 	return newFuncOption(func(oo *outputImageOptions) {

--- a/writer/standard/writer.go
+++ b/writer/standard/writer.go
@@ -183,6 +183,12 @@ func draw(mat qrcode.Matrix, opt *outputImageOptions) image.Image {
 		// EOFn
 	})
 
+	// Gradient fill
+	if opt.qrGradient != nil {
+		img := opt.qrGradient.applyGradient(dc.Image(), opt.qrColor)
+		dc.DrawImage(img, 0, 0)
+	}
+
 	// DONE(@yeqown): add logo image
 	if opt.logoImage() != nil {
 		// Draw logo image into rgba
@@ -201,9 +207,6 @@ func draw(mat qrcode.Matrix, opt *outputImageOptions) image.Image {
 		dc.DrawImage(opt.logoImage(), (w-logoWidth)/2, (h-logoHeight)/2)
 	}
 done:
-	if opt.qrGradient != nil {
-		return opt.qrGradient.applyGradient(dc.Image(), opt.qrColor)
-	}
 	return dc.Image()
 }
 

--- a/writer/standard/writer.go
+++ b/writer/standard/writer.go
@@ -201,6 +201,9 @@ func draw(mat qrcode.Matrix, opt *outputImageOptions) image.Image {
 		dc.DrawImage(opt.logoImage(), (w-logoWidth)/2, (h-logoHeight)/2)
 	}
 done:
+	if opt.qrGradient != nil {
+		return opt.qrGradient.applyGradient(dc.Image(), opt.qrColor)
+	}
 	return dc.Image()
 }
 


### PR DESCRIPTION
### Add: Linear Gradient Color Support for QR Code Rendering
Example:
```go
qrc, err := qrcode.NewWith("https://github.com/yeqown/go-qrcode")
if err != nil {
	panic(err)
}
// define gradient
g := standard.NewGradient(45, 	// gradient propagation angle
	[]standard.ColorStop{		// colors of the gradient
		{
			T:     0,
			Color: color.RGBA{R: 255, G: 0, B: 0, A: 255},
		},
		{
			T:     0.5,
			Color: color.RGBA{R: 0, G: 255, B: 0, A: 255},
		},
		{
			T:     1,
			Color: color.RGBA{R: 0, G: 0, B: 255, A: 255},
		},
	}...)
w, err := standard.New("./with-gradient-color/smaller.png",
	standard.WithFgGradient(g))
if err != nil {
	panic(err)
}
```

![image](https://github.com/user-attachments/assets/7ddbeb96-fa55-4456-ab42-bb77c64ab81b)

