### PR TITLE
feat(writer/standard): add logoSafeZone options

### DIFF
--- a/writer/standard/image_option.go
+++ b/writer/standard/image_option.go
@@ -46,6 +46,10 @@ type outputImageOptions struct {
 
 	logoSizeMultiplier int
 
+	// logoSafeZone indicates whether to reserve a clear area around the logo,
+	// preventing QR code blocks from being drawn underneath it.
+	logoSafeZone bool
+
 	// qrWidth width of each qr block
 	qrWidth int
 

--- a/writer/standard/image_option_api.go
+++ b/writer/standard/image_option_api.go
@@ -237,3 +237,10 @@ func WithLogoSizeMultiplier(multiplier int) ImageOption {
 		oo.logoSizeMultiplier = multiplier
 	})
 }
+
+// WithLogoSafeZone enables the safe zone logic around the logo area.
+func WithLogoSafeZone() ImageOption {
+	return newFuncOption(func(oo *outputImageOptions) {
+		oo.logoSafeZone = true
+	})
+}


### PR DESCRIPTION
📦 Pull Request: Add option to standard writer to prevent logo overlap with QR blocks

This PR introduces an option that improves QR code rendering by avoiding drawing QR blocks beneath the logo area. This ensures better visibility of the logo and reduces visual noise in the final image.

Usage example:
```go
w, err := standard.New(
	"./simple.png",
	standard.WithLogoImageFileJPEG("./logo.jpg"),
	standard.WithLogoSafeZone(),
)
```

Results:
![image](https://github.com/user-attachments/assets/34fc0fa0-9a23-4def-93fd-4f3801fe8e65)
![image](https://github.com/user-attachments/assets/854ecef8-cc47-43d2-9b81-6a3f2b04d18a)
![image](https://github.com/user-attachments/assets/7b61084b-f4c8-42d0-a47b-acaf28dfde48)
![image](https://github.com/user-attachments/assets/6da77f4d-cedd-4f7c-b6f4-dcdf76136639)
![image](https://github.com/user-attachments/assets/de8edd6f-deaf-4af4-b743-68e5c85b272a)
