### PR TITLE
feat(writer/standard): extend DrawContext with Neighbours bitmask

### DIFF
--- a/example/assemble-shape/main.go
+++ b/example/assemble-shape/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/yeqown/go-qrcode/v2"
+	"github.com/yeqown/go-qrcode/writer/standard"
+	"github.com/yeqown/go-qrcode/writer/standard/shapes"
+)
+
+func HChainBlock(ctx *standard.DrawContext) {
+	w, h := ctx.Edge()
+	fw, fh := float64(w), float64(h)
+	x, y := ctx.UpperLeft()
+	cx, cy := x+fw/2, y+fh/2
+	r := fw * 0.85 / 2 // todo:
+	l := r * 0.2
+
+	ctx.SetColor(ctx.Color())
+
+	mask := ctx.Neighbours()
+
+	drawRect := func(x, y, w, h float64) {
+		ctx.DrawRectangle(x, y, w, h)
+		ctx.Fill()
+	}
+	_ = mask
+	_ = drawRect
+
+	ctx.DrawCircle(cx, cy, r)
+
+	if mask&standard.NLeft|standard.NSelf == standard.NLeft|standard.NSelf {
+		drawRect(x, cy-l, fw/2, 2*l)
+	}
+	if mask&standard.NRight|standard.NSelf == standard.NRight|standard.NSelf {
+		drawRect(cx, cy-l, fw/2, 2*l)
+	}
+
+	ctx.Fill()
+}
+
+func main() {
+	// assemble qr injecting build in function or you own for drawing
+
+	shape := shapes.Assemble(shapes.RoundedFinder(), shapes.LiquidBlock())
+	//shape := shapes.Assemble(shapes.RoundedFinder(), HChainBlock)
+
+	qrc, err := qrcode.New(`https://github.com/yeqown/go-qrcode`)
+	if err != nil {
+		panic(err)
+	}
+
+	w, err := standard.New("./smaller.png",
+		standard.WithCustomShape(shape),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = qrc.Save(w)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/writer/standard/image_qr_shape.go
+++ b/writer/standard/image_qr_shape.go
@@ -26,7 +26,8 @@ type DrawContext struct {
 	x, y float64
 	w, h int
 
-	color color.Color
+	color      color.Color
+	neighbours uint16
 }
 
 // UpperLeft returns the point which indicates the upper left position.
@@ -37,6 +38,28 @@ func (dc *DrawContext) UpperLeft() (dx, dy float64) {
 // Edge returns width and height of each shape could take at most.
 func (dc *DrawContext) Edge() (width, height int) {
 	return dc.w, dc.h
+}
+
+// Bit flags for the 8 surrounding cells in a 3x3 grid around the center (x, y).
+// Layout:
+// NTopLeft		NTop 	NTopRight
+// NLeft  		NSelf	NRight
+// NBotLeft 	NBot 	NBotRight
+const (
+	NTopLeft  uint16 = 1 << iota // top-left
+	NTop                         // top
+	NTopRight                    // top-right
+	NLeft                        // left
+	NSelf                        // center (self)
+	NRight                       // right
+	NBotLeft                     // bottom-left
+	NBot                         // bottom
+	NBotRight                    // bottom-right
+)
+
+// Neighbours returns a bitmask representing the neighboring blocks of the current block
+func (dc *DrawContext) Neighbours() uint16 {
+	return dc.neighbours
 }
 
 // Color returns the color which should be fill into the shape. Note that if you're not

--- a/writer/standard/shapes/blocks.go
+++ b/writer/standard/shapes/blocks.go
@@ -1,0 +1,350 @@
+package shapes
+
+import "github.com/yeqown/go-qrcode/writer/standard"
+
+// LiquidBlock returns a drawing function that renders QR-code-like blocks
+// with smooth, organic, fluid transitions based on neighboring cell presence.
+// It creates a visually connected, blob-style appearance by dynamically adjusting
+// corners and sides depending on the surrounding cell mask.
+func LiquidBlock() func(ctx *standard.DrawContext) {
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+		fw, fh := float64(w), float64(h)
+		x, y := ctx.UpperLeft()
+		cx, cy := x+fw/2, y+fh/2
+		r := fw / 2
+		l := fw / 2
+
+		ctx.SetColor(ctx.Color())
+
+		type angleDrawer func(ctx *standard.DrawContext)
+		var (
+			AngTopRight angleDrawer = func(ctx *standard.DrawContext) {
+				ctx.MoveTo(cx, cy+r)
+				ctx.LineTo(cx-r, cy)
+				ctx.LineTo(cx-r, y)
+				ctx.LineTo(cx+r, y-l)
+				ctx.QuadraticTo(cx+r, cy-r, x+fw+l, cy-r)
+				ctx.LineTo(x+fw, cy+r)
+				ctx.ClosePath()
+			}
+			AngTopLeft angleDrawer = func(ctx *standard.DrawContext) {
+				ctx.MoveTo(cx, cy+r)
+				ctx.LineTo(cx+r, cy)
+				ctx.LineTo(cx+r, y-l)
+				ctx.LineTo(cx-r, y-l)
+				ctx.QuadraticTo(cx-r, cy-r, x-l, cy-r)
+				ctx.LineTo(x-l, cy+r)
+				ctx.ClosePath()
+			}
+			AngBotLeft angleDrawer = func(ctx *standard.DrawContext) {
+				ctx.MoveTo(cx, cy-r)
+				ctx.LineTo(cx+r, cy)
+				ctx.LineTo(cx+r, y+fh+l)
+				ctx.LineTo(cx-r, y+fh+l)
+				ctx.QuadraticTo(cx-r, cy+r, x-l, cy+r)
+				ctx.LineTo(x-l, cy-r)
+				ctx.ClosePath()
+			}
+			AngBotRight angleDrawer = func(ctx *standard.DrawContext) {
+				ctx.MoveTo(cx, cy-r)
+				ctx.LineTo(cx-r, cy)
+				ctx.LineTo(cx-r, y+fh+l)
+				ctx.LineTo(cx+r, y+fh+l)
+				ctx.QuadraticTo(cx+r, cy+r, x+fw+l, cy+r)
+				ctx.LineTo(x+fw, cy-r)
+				ctx.ClosePath()
+			}
+		)
+
+		mask := ctx.Neighbours()
+
+		drawRect := func(x, y, w, h float64) {
+			ctx.DrawRectangle(x, y, w, h)
+			ctx.Fill()
+		}
+
+		switch mask {
+		case standard.NRight | standard.NSelf:
+			drawRect(cx, cy-r, fw/2, 2*r)
+		case standard.NTop | standard.NSelf:
+			drawRect(cx-r, y, 2*r, fh/2)
+		case standard.NLeft | standard.NSelf:
+			drawRect(x, cy-r, fw/2, 2*r)
+		case standard.NBot | standard.NSelf:
+			drawRect(cx-r, y+fh/2, 2*r, fh/2)
+		case standard.NLeft | standard.NSelf | standard.NRight:
+			drawRect(x-fw/2, cy-r, 2*fw, 2*r)
+		}
+
+		if has(mask, standard.NLeft|standard.NSelf|standard.NRight) {
+			drawRect(x-fw/2, cy-r, 2*fw, 2*r)
+		}
+		if has(mask, standard.NTop|standard.NSelf|standard.NBot) {
+			drawRect(cx-r, y-fh/2, 2*r, 2*fh)
+		}
+		if has(mask, standard.NLeft|standard.NSelf) {
+			drawRect(x, cy-r, fw/2, 2*r)
+		}
+		if has(mask, standard.NSelf|standard.NRight) {
+			drawRect(cx, cy-r, fw/2, 2*r)
+		}
+		if has(mask, standard.NSelf|standard.NTop) {
+			drawRect(cx-r, y, 2*r, fh/2)
+		}
+		if has(mask, standard.NSelf|standard.NBot) {
+			drawRect(cx-r, y+fh/2, 2*r, fh/2)
+		}
+
+		if has(mask, standard.NBot|standard.NRight|standard.NSelf) && mask&standard.NBotRight == 0 {
+			AngBotRight(ctx)
+			ctx.Fill()
+		}
+		if has(mask, standard.NBot|standard.NLeft|standard.NSelf) && mask&standard.NBotLeft == 0 {
+			AngBotLeft(ctx)
+			ctx.Fill()
+		}
+		if has(mask, standard.NTop|standard.NLeft|standard.NSelf) && mask&standard.NTopLeft == 0 {
+			AngTopLeft(ctx)
+			ctx.Fill()
+		}
+		if has(mask, standard.NTop|standard.NRight|standard.NSelf) && mask&standard.NTopRight == 0 {
+			AngTopRight(ctx)
+			ctx.Fill()
+		}
+
+		ctx.DrawCircle(cx, cy, r)
+		ctx.Fill()
+	}
+}
+
+// HStripeBlock returns a drawing function that renders a QR-code-like block
+// with horizontal stripe connections. The width of each stripe is determined
+// by the stripeRatio parameter, which should be in the range [0.6, 1.0].
+// If the given ratio is out of bounds, a default of 0.85 is used.
+func HStripeBlock(stripeRatio float64) func(ctx *standard.DrawContext) {
+	if stripeRatio < 0.6 || stripeRatio > 1 {
+		stripeRatio = 0.85
+	}
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+		fw, fh := float64(w), float64(h)
+		x, y := ctx.UpperLeft()
+		cx, cy := x+fw/2, y+fh/2
+		r := fw * 0.9 / 2
+
+		ctx.SetColor(ctx.Color())
+
+		mask := ctx.Neighbours()
+
+		drawRect := func(x, y, w, h float64) {
+			ctx.DrawRectangle(x, y, w, h)
+			ctx.Fill()
+		}
+
+		ctx.DrawCircle(cx, cy, r)
+
+		if has(mask, standard.NLeft|standard.NSelf) {
+			drawRect(x, cy-r, fw/2, 2*r)
+		}
+		if has(mask, standard.NRight|standard.NSelf) {
+			drawRect(cx, cy-r, fw/2, 2*r)
+		}
+
+		ctx.Fill()
+	}
+}
+
+// VStripeBlock returns a drawing function that renders a QR-code-like block
+// with vertical stripe connections. The width of each stripe is determined
+// by the stripeRatio parameter, which should be in the range [0.6, 1.0].
+// If the given ratio is out of bounds, a default of 0.85 is used.
+func VStripeBlock(stripeRatio float64) func(ctx *standard.DrawContext) {
+	if stripeRatio < 0.6 || stripeRatio > 1 {
+		stripeRatio = 0.85
+	}
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+		fw, fh := float64(w), float64(h)
+		x, y := ctx.UpperLeft()
+		cx, cy := x+fw/2, y+fh/2
+		r := fw * stripeRatio / 2
+
+		ctx.SetColor(ctx.Color())
+
+		mask := ctx.Neighbours()
+
+		drawRect := func(x, y, w, h float64) {
+			ctx.DrawRectangle(x, y, w, h)
+			ctx.Fill()
+		}
+		_ = mask
+		_ = drawRect
+
+		ctx.DrawCircle(cx, cy, r)
+
+		if has(mask, standard.NTop|standard.NSelf) {
+			drawRect(cx-r, y, 2*r, fh/2)
+		}
+		if has(mask, standard.NBot|standard.NSelf) {
+			drawRect(cx-r, cy, 2*r, fh/2)
+		}
+
+		ctx.Fill()
+	}
+}
+
+// ChainBlock returns a drawing function that renders a QR-code-like block
+// with a central circle and narrow "chain link" connectors extending in all four directions.
+func ChainBlock() func(ctx *standard.DrawContext) {
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+		fw, fh := float64(w), float64(h)
+		x, y := ctx.UpperLeft()
+		cx, cy := x+fw/2, y+fh/2
+		r := fw * 0.9 / 2
+		l := r * 0.2
+
+		ctx.SetColor(ctx.Color())
+
+		mask := ctx.Neighbours()
+
+		drawRect := func(x, y, w, h float64) {
+			ctx.DrawRectangle(x, y, w, h)
+			ctx.Fill()
+		}
+		_ = mask
+		_ = drawRect
+
+		ctx.DrawCircle(cx, cy, r)
+
+		if has(mask, standard.NTop|standard.NSelf) {
+			drawRect(cx-l, y, 2*l, fh/2)
+		}
+		if has(mask, standard.NBot|standard.NSelf) {
+			drawRect(cx-l, cy, 2*l, fh/2)
+		}
+		if has(mask, standard.NLeft|standard.NSelf) {
+			drawRect(x, cy-l, fw/2, 2*l)
+		}
+		if has(mask, standard.NRight|standard.NSelf) {
+			drawRect(cx, cy-l, fw/2, 2*l)
+		}
+
+		ctx.Fill()
+	}
+}
+
+// VChainBlock returns a drawing function that renders a QR-code-like block
+// with a central circle and narrow vertical "chain link" connectors to
+// neighboring blocks above and below.
+func VChainBlock() func(ctx *standard.DrawContext) {
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+		fw, fh := float64(w), float64(h)
+		x, y := ctx.UpperLeft()
+		cx, cy := x+fw/2, y+fh/2
+		r := fw * 0.85 / 2 // todo:
+		l := r * 0.2
+
+		ctx.SetColor(ctx.Color())
+
+		mask := ctx.Neighbours()
+
+		drawRect := func(x, y, w, h float64) {
+			ctx.DrawRectangle(x, y, w, h)
+			ctx.Fill()
+		}
+		_ = mask
+		_ = drawRect
+
+		ctx.DrawCircle(cx, cy, r)
+
+		if has(mask, standard.NTop|standard.NSelf) {
+			drawRect(cx-l, y, 2*l, fh/2)
+		}
+		if has(mask, standard.NBot|standard.NSelf) {
+			drawRect(cx-l, cy, 2*l, fh/2)
+		}
+
+		ctx.Fill()
+	}
+}
+
+// HChainBlock returns a drawing function that renders a QR-code-like block
+// with a central circle and narrow horizontal "chain link" connectors to
+// neighboring blocks on the left and right.
+func HChainBlock() func(ctx *standard.DrawContext) {
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+		fw, fh := float64(w), float64(h)
+		x, y := ctx.UpperLeft()
+		cx, cy := x+fw/2, y+fh/2
+		r := fw * 0.85 / 2 // todo:
+		l := r * 0.2
+
+		ctx.SetColor(ctx.Color())
+
+		mask := ctx.Neighbours()
+
+		drawRect := func(x, y, w, h float64) {
+			ctx.DrawRectangle(x, y, w, h)
+			ctx.Fill()
+		}
+		_ = mask
+		_ = drawRect
+
+		ctx.DrawCircle(cx, cy, r)
+
+		if has(mask, standard.NLeft|standard.NSelf) {
+			drawRect(x, cy-l, fw/2, 2*l)
+		}
+		if has(mask, standard.NRight|standard.NSelf) {
+			drawRect(cx, cy-l, fw/2, 2*l)
+		}
+
+		ctx.Fill()
+	}
+}
+
+// SquareBlocks returns a drawing function that renders a centered square block.
+// The size parameter defines the square's size relative to the available cell,
+// ranging from 0.1 (10%) to 1.0 (100%). Values outside this range default to 1.0.
+func SquareBlocks(size float64) func(ctx *standard.DrawContext) {
+	if size < 0.1 || size > 1.0 {
+		size = 1
+	}
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+
+		fw0, fh0 := float64(w), float64(h)
+		x0, y0 := ctx.UpperLeft()
+		cx, cy := x0+fw0/2, y0+fh0/2
+
+		fw, fh := fw0*size, fh0*size
+		x, y := cx-fw/2, cy-fh/2
+
+		ctx.SetColor(ctx.Color())
+		ctx.DrawRectangle(x, y, fw, fh)
+		ctx.Fill()
+	}
+}
+
+func CircleBlocks(size float64) func(ctx *standard.DrawContext) {
+	if size < 0.1 || size > 1.0 {
+		size = 1
+	}
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+
+		fw0, fh0 := float64(w), float64(h)
+		x0, y0 := ctx.UpperLeft()
+		cx, cy := x0+fw0/2, y0+fh0/2
+
+		r := (fw0 / 2) * size
+
+		ctx.SetColor(ctx.Color())
+		ctx.DrawCircle(cx, cy, r)
+		ctx.Fill()
+	}
+}

--- a/writer/standard/shapes/constructor.go
+++ b/writer/standard/shapes/constructor.go
@@ -1,0 +1,38 @@
+package shapes
+
+import "github.com/yeqown/go-qrcode/writer/standard"
+
+// ComposableShape implements the standard.IShape interface by delegating
+// drawing behavior to externally supplied functions.
+//
+// This type enables flexible composition of shape logic, allowing clients
+// to inject custom behavior for both the main shape (`Draw`) and its finder (`DrawFinder`).
+type ComposableShape struct {
+	onDrawFinder func(ctx *standard.DrawContext)
+	onDraw       func(ctx *standard.DrawContext)
+}
+
+// Draw executes the injected draw function to render the shape body.
+func (s *ComposableShape) Draw(ctx *standard.DrawContext) {
+	s.onDraw(ctx)
+}
+
+// DrawFinder executes the injected drawFinder function to render the shape's finder pattern.
+func (s *ComposableShape) DrawFinder(ctx *standard.DrawContext) {
+	s.onDrawFinder(ctx)
+}
+
+// Assemble creates a new ComposableShape instance by assigning provided drawing
+// functions. This allows dynamic, reusable construction of shape behaviors.
+func Assemble(drawFinder, drawBlock func(ctx *standard.DrawContext)) standard.IShape {
+	return &ComposableShape{
+		onDrawFinder: drawFinder,
+		onDraw:       drawBlock,
+	}
+}
+
+// ----------- helpers -----------
+
+func has(mask, bits uint16) bool {
+	return mask&bits == bits
+}

--- a/writer/standard/shapes/finders.go
+++ b/writer/standard/shapes/finders.go
@@ -1,0 +1,92 @@
+package shapes
+
+import "github.com/yeqown/go-qrcode/writer/standard"
+
+// RoundedFinder returns a function that renders the QR code's finder pattern
+// with rounded transitions at the corners
+func RoundedFinder() func(ctx *standard.DrawContext) {
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+		fw, fh := float64(w), float64(h)
+		x, y := ctx.UpperLeft()
+
+		lw := fw / 2
+		lh := fh / 2
+
+		ctx.SetColor(ctx.Color())
+
+		mask := ctx.Neighbours()
+		if mask&standard.NSelf != standard.NSelf {
+			return
+		}
+		switch {
+		// top right corners
+		case mask == (standard.NSelf | standard.NBot | standard.NLeft):
+			ctx.MoveTo(x, y)
+			ctx.QuadraticTo(x+fw, y, x+fw, y+fh)
+			ctx.LineTo(x, y+fh+lh)
+			ctx.QuadraticTo(x, y+fh, x-lw, y+fh)
+			ctx.ClosePath()
+		case mask == (standard.NSelf | standard.NBot | standard.NLeft | standard.NBotLeft):
+			ctx.MoveTo(x, y)
+			ctx.QuadraticTo(x+fw, y, x+fw, y+fh)
+			ctx.LineTo(x, y+fh)
+			ctx.ClosePath()
+		// top left corners
+		case mask == (standard.NSelf | standard.NBot | standard.NRight):
+			ctx.MoveTo(x, y+fh)
+			ctx.QuadraticTo(x, y, x+fw, y)
+			ctx.LineTo(x+fw+lw, y+fh)
+			ctx.QuadraticTo(x+fw, y+fh, x+fw, y+fh+lh)
+			ctx.ClosePath()
+		case mask == (standard.NSelf | standard.NBot | standard.NRight | standard.NBotRight):
+			ctx.MoveTo(x, y+fh)
+			ctx.QuadraticTo(x, y, x+fw, y)
+			ctx.LineTo(x+fw, y+fh)
+			ctx.ClosePath()
+		// bot left corners
+		case mask == (standard.NSelf | standard.NTop | standard.NRight):
+			ctx.MoveTo(x, y)
+			ctx.QuadraticTo(x, y+fh, x+fw, y+fh)
+			ctx.LineTo(x+fw+lw, y)
+			ctx.QuadraticTo(x+fw, y, x+fw, y-lh)
+			ctx.ClosePath()
+		case mask == (standard.NSelf | standard.NTop | standard.NRight | standard.NTopRight):
+			ctx.MoveTo(x, y)
+			ctx.QuadraticTo(x, y+fh, x+fw, y+fh)
+			ctx.LineTo(x+fw, y)
+			ctx.ClosePath()
+		// bot right corners
+		case mask == (standard.NSelf | standard.NTop | standard.NLeft):
+			ctx.MoveTo(x, y+fh)
+			ctx.QuadraticTo(x+fw, y+fh, x+fw, y)
+			ctx.LineTo(x, y-lh)
+			ctx.QuadraticTo(x, y, x-lw, y)
+			ctx.ClosePath()
+		case mask == (standard.NSelf | standard.NTop | standard.NLeft | standard.NTopLeft):
+			ctx.MoveTo(x, y+fh)
+			ctx.QuadraticTo(x+fw, y+fh, x+fw, y)
+			ctx.LineTo(x, y)
+			ctx.ClosePath()
+			ctx.Fill()
+		default:
+			ctx.DrawRectangle(x, y, fw, fh)
+		}
+
+		ctx.Fill()
+	}
+}
+
+// SquareFinder just square finder
+func SquareFinder() func(ctx *standard.DrawContext) {
+	return func(ctx *standard.DrawContext) {
+		w, h := ctx.Edge()
+
+		fw0, fh0 := float64(w), float64(h)
+		x0, y0 := ctx.UpperLeft()
+
+		ctx.SetColor(ctx.Color())
+		ctx.DrawRectangle(x0, y0, fw0, fh0)
+		ctx.Fill()
+	}
+}


### PR DESCRIPTION
Enhance `DrawContext` with `neighbours` bitmask for advanced block rendering.

Description:

### 1 Extended `DrawContext`:
This PR extends the DrawContext structure by introducing a new Neighbours field — a bitmask indicating which adjacent blocks are in the IsSet state.

The main goal is to provide additional context for drawing custom blocks. By knowing the state of neighboring blocks, rendering functions can create more visually complex or connected patterns, enabling designs like chains, links, or merged visual elements between adjacent blocks.

This change does not affect existing drawing logic but unlocks more flexibility for advanced block styling.

### 2: Add set of prebuilt drawing functions:
Introduced a collection of reusable drawing functions representing different block and finder styles. These functions are injectable into the ComposableShape type via standard.Assemble, allowing flexible QR code composition.

This makes it possible to easily mix and match different visual styles for finders and data blocks, helping generate unique and customizable QR code designs.

Example use prebuilt drawing functions:
```go
	shape := shapes.Assemble(shapes.RoundedFinder(), shapes.LiquidBlock())

	qrc, err := qrcode.New(`https://github.com/yeqown/go-qrcode`)
	if err != nil {
		panic(err)
	}

	w, err := standard.New("./smaller.png",
		standard.WithCustomShape(shape),
	)
	if err != nil {
		panic(err)
	}
```
Result:
![image](https://github.com/user-attachments/assets/5803940e-1894-49f3-93ff-8015b524eece)

More QR Examples:
![image](https://github.com/user-attachments/assets/47bbeba1-ba3f-4128-8620-160990a04ae0)
