### PR TITLE
Add Support for `string` and `[]byte` Inputs in QRCode Constructors

### DIFF
--- a/mask_test.go
+++ b/mask_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMask(t *testing.T) {
 	qrc := &QRCode{
-		sourceText:     "baidu.com google.com qq.com sina.com apple.com",
+		sourceRawBytes: []byte("baidu.com google.com qq.com sina.com apple.com"),
 		encodingOption: DefaultEncodingOption(),
 	}
 	err := qrc.init()


### PR DESCRIPTION
Hey @yeqown,

I would like to propose this PR that updates the QRCode constructors to accept both `string` and `[]byte` inputs. 

While the library itself already supports handling data in byte-mode encoding (EncModeByte), the existing constructors required callers to pass a string, leading to unnecessary conversions when working with raw byte data.

The new constructors use a simple generic constraint `(~string | ~[]byte)` in order to stay backwards-compatible with downstream consumers of this library and a helper function to normalize inputs to `[]byte` data. Internally, `build` now operates solely on raw bytes. The `sourceText` field appeared to be unused except for tests and thus has been removed in favor of the `sourceRawBytes` field that is consumed everywhere in the code internally in order to avoid duplication.

Test code has been updated accordingly, and a minor formatting change was made to the debugging logging I couldn't avoid because my code editor just kept reformatting that file, sorry for that.

Hope you like it!