### PR TITLE
feat(standard): accept io.Writer output

### DIFF
--- a/writer/standard/README.md
+++ b/writer/standard/README.md
@@ -18,7 +18,13 @@ writer, err := standard.New("filename", options...)
 
 // or use io.WriteCloser
 var w io.WriterCloser
-writer2, err := standard.NewWith(w, options...)
+writer2 := standard.NewWithWriter(w, options...)
+_ = writer2
+
+// or use io.Writer (e.g. bytes.Buffer)
+buf := &bytes.Buffer{}
+writer3 := standard.NewWithIOWriter(buf, options...)
+_ = writer3
 ```
 
 ### Options

--- a/writer/standard/writer.go
+++ b/writer/standard/writer.go
@@ -60,6 +60,23 @@ func NewWithWriter(writeCloser io.WriteCloser, opts ...ImageOption) *Writer {
 	}
 }
 
+// NewWithIOWriter wraps an io.Writer for standard output without requiring a Close implementation.
+func NewWithIOWriter(writer io.Writer, opts ...ImageOption) *Writer {
+	if writer == nil {
+		panic("writer could not be nil")
+	}
+	return NewWithWriter(nopCloser{Writer: writer}, opts...)
+}
+
+// nopCloser adapts an io.Writer to io.WriteCloser.
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error {
+	return nil
+}
+
 const (
 	_defaultFilename = "default.jpeg"
 	_defaultPadding  = 40

--- a/writer/standard/writer_test.go
+++ b/writer/standard/writer_test.go
@@ -1,6 +1,7 @@
 package standard
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"image/png"
@@ -175,6 +176,18 @@ func Test_Attribute(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, width, attr.W)
 	assert.Equal(t, height, attr.H)
+}
+
+func Test_NewWithIOWriter(t *testing.T) {
+	buf := &bytes.Buffer{}
+	writer := NewWithIOWriter(buf)
+	require.NotNil(t, writer)
+
+	mat := qrcode.NewMatrix(21)
+	require.NoError(t, mat.Set(0, 0, true))
+	require.NoError(t, writer.Write(mat))
+
+	require.Greater(t, buf.Len(), 0)
 }
 
 //


### PR DESCRIPTION
## Summary
- add `NewWithIOWriter` to wrap an `io.Writer` with a no-op Close
- document bytes.Buffer usage in standard writer README
- add test to ensure buffer output writes successfully

## Testing
- not run (read-only environment)
