### PR TITLE
Add WithHalftoneImage

### DIFF
--- a/writer/standard/image_option_api.go
+++ b/writer/standard/image_option_api.go
@@ -231,6 +231,14 @@ func WithHalftone(path string) ImageOption {
 	})
 }
 
+// WithHalftoneImage is identical to WithHalftone, but instead takes an image.Image as
+// input. This is useful if the image will not be saved to disk.
+func WithHalftoneImage(srcImg image.Image) ImageOption {
+	return newFuncOption(func(oo *outputImageOptions) {
+		oo.halftoneImg = srcImg
+	})
+}
+
 // WithLogoSizeMultiplier used in Writer in validLogoImage method to validate logo size
 func WithLogoSizeMultiplier(multiplier int) ImageOption {
 	return newFuncOption(func(oo *outputImageOptions) {


### PR DESCRIPTION
Add `WithHalftoneImage`, for when the halftone image is not stored on disk (such as when it came from a network request or similar.